### PR TITLE
Remove the requirement of memcached when install the python-memcached pa...

### DIFF
--- a/memcached/python_memcached.sls
+++ b/memcached/python_memcached.sls
@@ -1,10 +1,6 @@
 {% from 'memcached/map.jinja' import memcached with context %}
-include:
-  - memcached
 
 python-memcached:
   pkg:
     - installed
     - name: {{ memcached.python }}
-    - require:
-      - pkg: memcached


### PR DESCRIPTION
There is no need to install the memcached when installing python-memcached package.
