### PR TITLE
add RedHat config file support

### DIFF
--- a/memcached/config.sls
+++ b/memcached/config.sls
@@ -1,13 +1,19 @@
+{% from 'memcached/map.jinja' import memcached with context %}
+
 include:
   - memcached
 
-/etc/memcached.conf:
+{{ memcached.config_file }}:
   file:
     - managed
     - template: jinja
     - user: root
     - group: root
     - mode: 644
+    {% if grains['os_family'] == 'Debian' %}
     - source: salt://memcached/templates/memcached.conf
+    {% elif grains['os_family'] == 'RedHat' %}
+    - source: salt://memcached/templates/sysconfig/memcached
+    {% endif %}
     - watch_in:
       - service: memcached

--- a/memcached/map.jinja
+++ b/memcached/map.jinja
@@ -18,10 +18,12 @@
         'server': 'memcached',
         'service': 'memcached',
         'python': 'python-memcache',
+        'config_file': '/etc/memcached.conf',
     },
     'RedHat': {
         'server': 'memcached',
         'service': 'memcached',
         'python': 'python-memcached',
+        'config_file': '/etc/sysconfig/memcached',
     },
     }, merge=salt['pillar.get']('memcached:lookup')) %}

--- a/memcached/templates/sysconfig/memcached
+++ b/memcached/templates/sysconfig/memcached
@@ -1,0 +1,25 @@
+{% from 'memcached/macros.sls' import get_config_item with context -%}
+
+PORT="{{ get_config_item('port') }}"
+USER="{{ get_config_item('user') }}"
+MAXCONN="{{ get_config_item('max_connections') }}"
+CACHESIZE="{{ get_config_item('memory_cap') }}"
+OPTIONS="-l {{ get_config_item('listen_address') }}"
+
+{% if get_config_item('lock_paged_memory') == 'True' %}
+OPTIONS="$OPTIONS -k"
+{% endif %}
+
+{% if get_config_item('error_on_mem_full') == 'True' %}
+OPTIONS="$OPTIONS -M"
+{% endif %}
+
+{% if get_config_item('max_core_file_"limit') == 'True' %}
+OPTIONS="$OPTIONS -r"
+{% endif %}
+
+{% if get_config_item('verbose_level') == '1' %}
+OPTIONS="$OPTIONS -v >> {{ get_config_item('log_file') }} 2>&1"
+{% elif get_config_item('verbose_level') == '2' %}
+OPTIONS="$OPTIONS -vv >> {{ get_config_item('log_file') }} 2>&1"
+{% endif %}


### PR DESCRIPTION
on RedHat and CentOS systems, the memcached config file is stored in /etc/sysconfig/memcached and in a different format.

I've tested various permutation on CentOS 6.5 using memcached 1.4.4 with all variables from config from the base yum repo except for daemon which is hard coded in the init script.
