### PR TITLE
initial support for arch linux

### DIFF
--- a/memcached/config.sls
+++ b/memcached/config.sls
@@ -16,6 +16,8 @@ include:
     - source: salt://memcached/templates/sysconfig/memcached
     {% elif grains['os_family'] == 'Gentoo' %}
     - source: salt://memcached/templates/conf.d/memcached
+    {% elif grains['os_family'] == 'Arch' %}
+    - source: salt://memcached/templates/empty
     {% endif %}
     - watch_in:
       - service: memcached

--- a/memcached/map.jinja
+++ b/memcached/map.jinja
@@ -35,4 +35,11 @@
         'config_file': '/etc/conf.d/memcached',
         'libmemcached': 'dev-libs/libmemcached',
     },
+    'Arch':{
+        'server': 'memcached',
+        'service': 'memcached',
+        'python': 'python2-memcached',
+        'config_file': '/etc/memcached',
+        'libmemcached': 'libmemcached',
+    },
     }, merge=salt['pillar.get']('memcached:lookup')) %}


### PR DESCRIPTION
This adds initial support for arch linux. (I'm still a salt newbie, so it's not yet complete). Also arch linux does not offer a way to change the memcache config out of the box.