### PR TITLE
Allow to set the default slab item size

### DIFF
--- a/memcached/map.jinja
+++ b/memcached/map.jinja
@@ -11,6 +11,7 @@
         'lock_paged_memory': False,
         'error_on_mem_full': False,
         'max_core_file_limit': False,
+        'slab_size_limit': '1m',
     }  
 } %}
 {% set memcached = salt['grains.filter_by']({

--- a/memcached/templates/conf.d/memcached
+++ b/memcached/templates/conf.d/memcached
@@ -34,3 +34,7 @@ PIDBASE="/var/run/memcached/memcached"
 
 #Other Options
 MISC_OPTS=""
+
+{% if get_config_item('slab_size_limit') != '1m' %}
+MISC_OPTS="$MISC_OPTS -I {{ get_config_item('slab_size_limit') }}"
+{% endif %}

--- a/memcached/templates/memcached.conf
+++ b/memcached/templates/memcached.conf
@@ -47,3 +47,8 @@ logfile  {{ get_config_item('log_file') }}
 # Maximize core file limit
 # -r 
 {{ '-r' if get_config_item('max_core_file_limit') == 'True' else '' }}
+
+{% if get_config_item('slab_size_limit') != '1m' %}
+# Override the size of each slab page in bytes. In mundane words, it adjusts the maximum item size  that  memcached  will  accept.
+-I {{ get_config_item('slab_size_limit') }}
+{% endif %}

--- a/memcached/templates/sysconfig/memcached
+++ b/memcached/templates/sysconfig/memcached
@@ -14,8 +14,12 @@ OPTIONS="$OPTIONS -k"
 OPTIONS="$OPTIONS -M"
 {% endif %}
 
-{% if get_config_item('max_core_file_"limit') == 'True' %}
+{% if get_config_item('max_core_file_limit') == 'True' %}
 OPTIONS="$OPTIONS -r"
+{% endif %}
+
+{% if get_config_item('slab_size_limit') != '1m' %}
+OPTIONS="$OPTIONS -I {{ get_config_item('slab_size_limit') }}"
 {% endif %}
 
 {% if get_config_item('verbose_level') == '1' %}

--- a/pillar.example
+++ b/pillar.example
@@ -9,3 +9,4 @@ memcached:
   lock_paged_memory: False
   error_on_mem_full: False
   max_core_file_limit: False
+  slab_size_limit: '1m'


### PR DESCRIPTION
Well, sometimes the default isn't enought and we needed this kind of control at our company.

Also, I think there was a small typo:

`{% if get_config_item('max_core_file_"limit') == 'True' %}`

Where it should read:

`{% if get_config_item('max_core_file_limit') == 'True' %}`

Anyway it's working fine for us at a few OS flavors.