### PR TITLE
Add info about uninstall state

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,11 @@ Installs ``python-memcached`` package for RedHat/CentOS and ``python-memcache`` 
 
 Installs libmemcached development files to install ``pylibmc`` as python driver
 
+``memcached.uninstall``
+-------------
+
+Stops the memcached service and uninstalls the package.
+
 Instructions
 ============
 


### PR DESCRIPTION
This PR adds missing information about `memcached.uninstall` state