### PR TITLE
feat(freebsd): add basic freebsd support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 memcached
 =========
 
-Install and start the memcached service
+Install and start the memcached service on GNU/Linux and FreeBSD
 
 .. note::
 

--- a/memcached/init.sls
+++ b/memcached/init.sls
@@ -1,10 +1,27 @@
 {% from 'memcached/map.jinja' import memcached with context %}
 
 memcached:
+        {%- if grains.os_family in ('FreeBSD',) %}
+  cmd.run:
+    - names:
+      - portsnap fetch
+      - portsnap extract
+      - cd /usr/ports/distfiles
+      - curl -LO https://github.com/cyrusimap/cyrus-sasl/releases/download/cyrus-sasl-2.1.27/cyrus-sasl-2.1.27.tar.gz
+      - cd /usr/ports/databases/memcached && make deinstall && make install clean
+    - env:
+      - BATCH: 'yes'
+  sysrc.managed:
+    - name: memcached_enable
+    - value: YES
+    - require:
+      - cmd: memcached
+        {%- else %}
   pkg.installed:
     - name: {{ memcached.server }}
+        {%- endif %}
+    - require_in:
+      - service: memcached
   service.running:
     - enable: True
     - name: {{ memcached.service }}
-    - require:
-      - pkg: memcached

--- a/memcached/map.jinja
+++ b/memcached/map.jinja
@@ -22,6 +22,12 @@
         'config_file': '/etc/memcached.conf',
         'libmemcached': 'libmemcached-devel',
     },
+    'FreeBSD':{
+        'server': 'memcached',
+        'service': 'memcached',
+        'config_file': '/usr/local/etc/rc.d/memcached',
+        'libmemcached': 'libmemcached-devel',
+    },
     'Debian':{
         'server': 'memcached',
         'service': 'memcached',

--- a/memcached/map.jinja
+++ b/memcached/map.jinja
@@ -15,6 +15,13 @@
     }
 } %}
 {% set memcached = salt['grains.filter_by']({
+    'Suse':{
+        'server': 'memcached',
+        'service': 'memcached',
+        'python': 'python-python-memcache',
+        'config_file': '/etc/memcached.conf',
+        'libmemcached': 'libmemcached-devel',
+    },
     'Debian':{
         'server': 'memcached',
         'service': 'memcached',


### PR DESCRIPTION
<!--
Please fill in this PR template to make it easier to review and merge.

It has been designed so that a lot of it can be completed *after* submitting it,
e.g. filling in the checklists.

Notes:
1. Please keep the PR as small as is practicable; the larger a PR gets, the harder it becomes to review and the more time it requires to get it merged.
2. Similarly, please avoid PRs that cover more than one type; it should be a _bug fix_ *OR* a _new feature_ *OR* a _refactor_, etc.
3. Please direct questions to the [`#formulas` channel on Slack](https://saltstackcommunity.slack.com/messages/C7LG8SV54/), which is bridged to `#saltstack-formulas` on Freenode.
4. Feel free to suggest improvements to this template by reporting an issue or submitting a PR.  The source of this template is:
  - https://github.com/saltstack-formulas/.github/blob/master/.github/pull_request_template.md
-->

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [x] Changes to documentation are appropriate (or tick if not required)
- [x] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [x] `[feat]`     A new feature
- [ ] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [x] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->

#24

### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->



### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->



### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->

```
 .... <CUT> ...

                 http://memcached.org/
                  ===>  Cleaning for memcached-1.5.19
----------
          ID: memcached
    Function: sysrc.managed
        Name: memcached_enable
      Result: True
     Comment: The value of "memcached_enable" was changed!
     Started: 01:30:38.754192
    Duration: 117.25 ms
     Changes:   
              ----------
              new:
                  ----------
                  /etc/rc.conf:
                      ----------
                      memcached_enable:
                           YES
              old:
                  ----------
                  /etc/rc.conf:
                      ----------
                      memcached_enable:
                          YES
----------
          ID: memcached
    Function: service.running
      Result: True
     Comment: The service memcached is already running
     Started: 01:30:38.879388
    Duration: 75.412 ms
     Changes:   

Summary for local
------------
Succeeded: 7 (changed=6)
Failed:    0
------------
Total states run:     7
Total run time: 178.760 s
[vagrant@bazinga /usr/local/etc/salt/states]$ 
```

### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->